### PR TITLE
reject with error on non 200

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bxm/pro-request",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "This library wraps the request library with an ES6 promise",
   "main": "index.js",
   "scripts": {
@@ -26,6 +26,7 @@
   "license": "",
   "readme": "README.md",
   "dependencies": {
+    "lodash.isstring": "^4.0.1",
     "request": "^2.57.0"
   },
   "devDependencies": {

--- a/src/prorequest.js
+++ b/src/prorequest.js
@@ -1,4 +1,5 @@
 import request from 'request';
+import isString from 'lodash.isstring';
 
 function makeRequest(method, url, parameters) {
     return new Promise((resolve, reject) => {
@@ -17,9 +18,9 @@ function makeRequest(method, url, parameters) {
             proxy: process.env.HTTP_PROXY || '',
             json: json
         };
-        request(options, (error, response) => {
+        request(options, (error, response, body) => {
             if (error) return reject(error);
-            if (response.statusCode < 200 || response.statusCode >= 300) return reject(response);
+            if (response.statusCode < 200 || response.statusCode >= 300) return reject(new Error(`status: ${response.statusCode}, url: ${url}, body: ${isString(body) ? body : JSON.stringify(body)}`));
             resolve(response);
         });
     });

--- a/tests/unit/prorequestSpec.js
+++ b/tests/unit/prorequestSpec.js
@@ -62,7 +62,7 @@ describe('prorequest', () => {
             const actual = webRequestUtil.get('http://test.com', {'headers': {'Content-Type': 'application/json'}, 'json': {'test': 'test'}});
 
             actual.then(() => {}).catch((err) => {
-                expect(err).to.deep.equal({'statusCode': 500, 'body': {'test': 'fail'}});
+                expect(err.message).to.equal(`status: 500, url: http://test.com, body: ${JSON.stringify(body)}`);
                 done();
                 // This second catch is to catch any errors with the expect in the above catch
             }).catch((err) => {


### PR DESCRIPTION
changing non-200 status code to reject with error

only problem is new Error() basically only takes a string error message

so if we want url, status + body need to concat into a string

other issue is that body can be a string or json

@hiro 
