### PR TITLE
Removing reading HTTP_PROXY as request does this

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pro-request",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Wraps the Request library with a light weight ES6 promise.",
   "main": "index.js",
   "keywords": [

--- a/src/prorequest.js
+++ b/src/prorequest.js
@@ -18,7 +18,7 @@ function makeRequest(method, url, parameters) {
             json = parameters.json;
         }
 
-        const options = { method, url, headers, proxy: process.env.HTTP_PROXY || '', json };
+        const options = { method, url, headers, json };
 
         request(options, (error, response, body) => {
             if (error) return reject(error);


### PR DESCRIPTION
Removing the passing through of the HTTP_PROXY to request library. Request already reads that environment variable, and by passing it in request doesn't use the other environment variables like NO_PROXY.

If we ever want to override the HTTP_PROXY value by passing it in as the options to Request, we can update it then.